### PR TITLE
Don't hard code the box url

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,5 @@
 Vagrant.configure('2') do |config|
   config.vm.box      = 'precise64'
-  config.vm.box_url  = 'http://files.vagrantup.com/precise64.box'
 
   config.vm.provision :shell, :path => "bootstrap.sh"
 end


### PR DESCRIPTION
Allow vagrant to select the box url based on the current provider. For example, if you set your default provider in vagrant to hyperv, `vagrant up` will fail because that hardcoded url is a virtualbox box. I think with the current version of vagrant, just allowing vagrant to resolve the url itself based on the box name and current provider should be sufficient.

Thoughts?
