### PR TITLE
Change Rubies installation to reduce duplication

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -73,10 +73,10 @@ fi
 
 # install rubies
 $as_vagrant 'rvm install jruby'
-$as_vagrant 'rvm install 2.1'
-$as_vagrant 'rvm install 2.0.0'
+$as_vagrant 'rvm install 1.8.7-p374'
 $as_vagrant 'rvm install 1.9.3'
-$as_vagrant 'rvm install 1.8.7'
+$as_vagrant 'rvm install 2.0.0'
+$as_vagrant 'rvm install 2.1'
 
 # add /vagrant/bin to the PATH
 if ! grep -q "/vagrant/bin" $home/.bash_profile; then


### PR DESCRIPTION
Ruby 1.9.x and 2.x requires Ruby 1.8.x as pre-requisite.

When installing 2.1, RVM triggers the installation of 1.8.7-head
before, and then we install latest 1.8.7.

This change ensures that Ruby 1.8.7 is installed first so others
can depend on it and avoid multiple 1.8.7 installations.

Due Ruby 1.8.7 EOL, we are going to set a specific patchlevel for
it to avoid rvm installing `head` version of it too.

This has reduced the bootstrap time considerably (since it no longer requires to build Ruby 1.8.7 twice).

Thank you! :heart: :heart: :heart: 
