### PR TITLE
RVM 1.26.0+ has signed releases — needs public key

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -61,6 +61,7 @@ fi
 $as_vagrant 'echo "gem: --no-ri --no-rdoc" >> ~/.gemrc'
 
 # install rvm
+$as_vagrant 'gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3' # RVM 1.26.0+ has signed releases
 $as_vagrant 'curl -L https://get.rvm.io | bash -s stable'
 
 # source rvm for usage outside of package scripts


### PR DESCRIPTION
See https://github.com/wayneeseguin/rvm/issues/3110
