### PR TITLE
Bump Rubies: 1.9.3-p551, 2.0.0-p645, 2.1.6, and add 2.2.2

### DIFF
--- a/bin/package_win32_fat_binary
+++ b/bin/package_win32_fat_binary
@@ -13,7 +13,7 @@ cd '/vagrant'
 cd $1
 
 base_version=${BASE_VERSION:-1.9.3}
-cc_versions=${RUBY_CC_VERSION:-1.8.7:1.9.3:2.0.0:2.1.4}
+cc_versions=${RUBY_CC_VERSION:-1.8.7:1.9.3:2.0.0:2.1.6:2.2.2}
 
 # Use Ruby 1.9.3 as base to cross-compile to different versions
 rvm use $base_version

--- a/bin/prepare_xrubies
+++ b/bin/prepare_xrubies
@@ -24,22 +24,29 @@ rake-compiler cross-ruby VERSION=1.8.7-p374 HOST=i586-mingw32msvc
 
 # Build 1.9.3 using 1.9.3 as base
 rvm use 1.9.3
-rake-compiler cross-ruby VERSION=1.9.3-p550 HOST=i586-mingw32msvc
+rake-compiler cross-ruby VERSION=1.9.3-p551 HOST=i586-mingw32msvc
 
 # Use all CPUs for building 2.0+
 export MAKE="make -j$(nproc)"
 
 # Build Ruby 2.0.0
-rake-compiler cross-ruby VERSION=2.0.0-p594 HOST=i686-w64-mingw32 debugflags="-g"
+rake-compiler cross-ruby VERSION=2.0.0-p645 HOST=i686-w64-mingw32 debugflags="-g"
 
 # Build x64 Ruby 2.0.0
-rake-compiler cross-ruby VERSION=2.0.0-p594 HOST=x86_64-w64-mingw32 debugflags="-g"
+rake-compiler cross-ruby VERSION=2.0.0-p645 HOST=x86_64-w64-mingw32 debugflags="-g"
 
 # Build Ruby 2.1
-rake-compiler cross-ruby VERSION=2.1.4 HOST=i686-w64-mingw32 debugflags="-g"
+rake-compiler cross-ruby VERSION=2.1.6 HOST=i686-w64-mingw32 debugflags="-g"
 
 # Build x64 Ruby 2.1
-rake-compiler cross-ruby VERSION=2.1.4 HOST=x86_64-w64-mingw32 debugflags="-g"
+rake-compiler cross-ruby VERSION=2.1.6 HOST=x86_64-w64-mingw32 debugflags="-g"
+
+# Build Ruby 2.2 using 2.0.0 as base
+rvm use 2.0.0
+rake-compiler cross-ruby VERSION=2.2.2 HOST=i686-w64-mingw32 debugflags="-g"
+
+# Build x64 Ruby 2.2
+rake-compiler cross-ruby VERSION=2.2.2 HOST=x86_64-w64-mingw32 debugflags="-g"
 
 # Mark installation prepared and don't run all this again
 touch "$HOME/.rake-compiler/.prepared"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -78,6 +78,7 @@ $as_vagrant 'rvm install 1.8.7-p374'
 $as_vagrant 'rvm install 1.9.3'
 $as_vagrant 'rvm install 2.0.0'
 $as_vagrant 'rvm install 2.1'
+$as_vagrant 'rvm install 2.2'
 
 # add /vagrant/bin to the PATH
 if ! grep -q "/vagrant/bin" $home/.bash_profile; then


### PR DESCRIPTION
I was not able to build Ruby 2.2.1 using RVM 1.9.3, so I switched to RVM 2.0.0 for the 2.2.1 builds. Now they fail in a novel way - apparently trying to load a Windows DLL at build time:

```
ruby --disable=gems -I/home/vagrant/.rake-compiler/builds/i686-w64-mingw32/ruby-2.2.1 -ri386-mingw32-fake  -I`cd /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib; pwd` --disable-gems -r./i386-mingw32-fake /home/vagrant/.rake-compiler/sources/ruby-2.2.1/tool/rbinstall.rb --make="make -j2" --dest-dir="" --extout=".ext" --mflags="- --jobserver-fds=4,5 -j" --make-flags=" --jobserver-fds=4,5 -j" --data-mode=0644 --prog-mode=0755 --installed-list .installed.list --mantype="doc"
installing binary commands:   /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/bin
installing base libraries:    /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib
installing arch files:        /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/2.2.0/i386-mingw32
installing pkgconfig data:    /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/pkgconfig
installing command scripts:   /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/bin
installing library scripts:   /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/2.2.0
installing common headers:    /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/include/ruby-2.2.0
installing manpages:          /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/share/man/man1
installing extension objects: /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/2.2.0/i386-mingw32
installing extension objects: /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/i386-msvcrt
installing extension objects: /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/vendor_ruby/2.2.0/i386-msvcrt
installing extension headers: /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/include/ruby-2.2.0/i386-mingw32
installing extension scripts: /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/2.2.0
installing extension scripts: /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/site_ruby/2.2.0
installing extension scripts: /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/vendor_ruby/2.2.0
installing extension headers: /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/include/ruby-2.2.0/ruby
installing default gems:      /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/gems/2.2.0 (build_info, cache, doc, extensions, gems, specifications)
                              bigdecimal 1.2.6
                              io-console 0.4.3
                              json 1.8.1
                              psych 2.0.8
                              rake 10.4.2
                              rdoc 4.2.0
installing bundle gems:       /home/vagrant/.rake-compiler/ruby/i686-w64-mingw32/ruby-2.2.1/lib/ruby/gems/2.2.0 (build_info, cache, doc, extensions, gems, specifications)
/home/vagrant/.rvm/rubies/ruby-2.0.0-p594/lib/ruby/2.0.0/fiddle/import.rb:85:in `rescue in block in dlload': can't load advapi32 (Fiddle::DLError)
	from /home/vagrant/.rvm/rubies/ruby-2.0.0-p594/lib/ruby/2.0.0/fiddle/import.rb:82:in `block in dlload'
	from /home/vagrant/.rvm/rubies/ruby-2.0.0-p594/lib/ruby/2.0.0/fiddle/import.rb:73:in `collect'
	from /home/vagrant/.rvm/rubies/ruby-2.0.0-p594/lib/ruby/2.0.0/fiddle/import.rb:73:in `dlload'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/securerandom.rb:48:in `<module:AdvApi32>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/securerandom.rb:46:in `<module:SecureRandom>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/securerandom.rb:42:in `<top (required)>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/resolv.rb:6:in `<top (required)>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/remote_fetcher.rb:6:in `<top (required)>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/spec_fetcher.rb:1:in `<top (required)>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/dependency_installer.rb:5:in `<top (required)>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/lib/rubygems.rb:556:in `install'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/tool/rbinstall.rb:722:in `block (2 levels) in <main>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/tool/rbinstall.rb:721:in `each'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/tool/rbinstall.rb:721:in `block in <main>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/tool/rbinstall.rb:757:in `call'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/tool/rbinstall.rb:757:in `block in <main>'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/tool/rbinstall.rb:754:in `each'
	from /home/vagrant/.rake-compiler/sources/ruby-2.2.1/tool/rbinstall.rb:754:in `<main>'
make: *** [do-install-nodoc] Error 1
```